### PR TITLE
Low-level sequence decoder

### DIFF
--- a/src/decodeStream.ts
+++ b/src/decodeStream.ts
@@ -80,6 +80,12 @@ export class DecodeStream implements Sliceable {
     }
   }
 
+  public *seq(): ValueGenerator {
+    while (this.#offset < this.#src.length) {
+      yield *this.#nextVal(0);
+    }
+  }
+
   /**
    * Get the next CBOR value from the input stream.  Yields Value tuples.
    *

--- a/src/decoder.ts
+++ b/src/decoder.ts
@@ -1,21 +1,11 @@
-import type {DecodeOptions, Parent} from './options.js';
+import type {DecodeOptions, Parent, MtAiValue as Tuple} from './options.js';
+import {DecodeStream, type ValueGenerator} from './decodeStream.js';
 import {CBORcontainer} from './container.js';
-import {DecodeStream} from './decodeStream.js';
 import {SYMS} from './constants.js';
 
-/**
- * Decode CBOR bytes to a JS value.
- *
- * @param src CBOR bytes to decode.
- * @param options Options for decoding.
- * @returns JS value decoded from cbor.
- * @throws {Error} No value found, decoding errors.
- */
-// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
-export function decode<T = unknown>(
-  src: Uint8Array | string,
-  options: DecodeOptions = {}
-): T {
+function normalizeOptions(
+  options: DecodeOptions
+): Required<DecodeOptions> {
   const opts = {...CBORcontainer.defaultDecodeOptions};
   if (options.dcbor) {
     Object.assign(opts, CBORcontainer.dcborDecodeOptions);
@@ -31,6 +21,24 @@ export function decode<T = unknown>(
   if (opts.boxed) {
     opts.saveOriginal = true;
   }
+
+  return opts;
+}
+
+/**
+ * Decode CBOR bytes to a JS value.
+ *
+ * @param src CBOR bytes to decode.
+ * @param options Options for decoding.
+ * @returns JS value decoded from cbor.
+ * @throws {Error} No value found, decoding errors.
+ */
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
+export function decode<T = unknown>(
+  src: Uint8Array | string,
+  options: DecodeOptions = {}
+): T {
+  const opts = normalizeOptions(options);
   const stream = new DecodeStream(src, opts);
   let parent: Parent | undefined = undefined;
   let ret: unknown = undefined;
@@ -63,4 +71,56 @@ export function decode<T = unknown>(
     }
   }
   return ret as T;
+}
+
+export {Tuple};
+
+/**
+ * Decode CBOR Sequence bytes to major-type/additional-information/value tuples.
+ */
+export class Sequence {
+  #seq: ValueGenerator;
+  #peeked: Tuple | undefined;
+
+  public constructor(src: Uint8Array | string, options: DecodeOptions = {}) {
+    const stream = new DecodeStream(src, normalizeOptions(options));
+    this.#seq = stream.seq();
+  }
+
+  /** Peek at the next tuple, allowing for later reads. */
+  public peek(): Tuple | undefined {
+    if (!this.#peeked) {
+      this.#peeked = this.#next();
+    }
+    return this.#peeked;
+  }
+
+  /** Read the next tuple. */
+  public read(): Tuple | undefined {
+    const mav = this.#peeked ?? this.#next();
+    this.#peeked = undefined;
+    return mav;
+  }
+
+  /** Iterate over all tuples. */
+  public *[Symbol.iterator](): Generator<Tuple, void, undefined> {
+    while (true) {
+      const tuple = this.read();
+
+      if (!tuple) {
+        return;
+      }
+
+      yield tuple;
+    }
+  }
+
+  #next(): Tuple | undefined {
+    const {value: tuple, done} = this.#seq.next();
+    if (done) {
+      return undefined;
+    }
+
+    return tuple;
+  }
 }


### PR DESCRIPTION
Allows low-level decoding of CBOR sequences, yielding tuples with major type, additional information & values.

Sequences can be iterated as is, but also supports peek() to look at the next value, and read() which consumes that value.